### PR TITLE
fix: click link ele will open new win in workspace

### DIFF
--- a/src.main/index.js
+++ b/src.main/index.js
@@ -48,6 +48,12 @@ function createWindow () {
       webviewTag: true,
     }
   })
+
+  win.webContents.setWindowOpenHandler(() => {
+    // TODO: need add condition for the external link in the code editor
+    return { action: 'deny' }
+  })
+
   win.loadURL(
     isDev
       ? 'http://localhost:3000'

--- a/src/react.js
+++ b/src/react.js
@@ -26,6 +26,9 @@ if (!process.env.CDN) {
 document.title = process.env.PROJECT_NAME
 ReactDOM.render(<App />, document.getElementById('root'))
 
+window.addEventListener('auxclick', (event) => {
+  if (event.button === 1) event.preventDefault()
+})
 // If you want your app to work offline and load faster, you can change
 // unregister() to register() below. Note this comes with some pitfalls.
 // Learn more about service workers: http://bit.ly/CRA-PWA


### PR DESCRIPTION
disable open new window globally when  clicking the link element by mouse middle button